### PR TITLE
Add local development setup role

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -26,3 +26,4 @@
     - { role: wp-cli, tags: [wp-cli] }
     - { role: wordpress-setup, tags: [wordpress, wordpress-setup] }
     - { role: wordpress-install, tags: [wordpress, wordpress-install] }
+    - { role: local-development, tags: [local-development] }

--- a/roles/local-development/tasks/enable-theme.yml
+++ b/roles/local-development/tasks/enable-theme.yml
@@ -1,0 +1,7 @@
+- name: Enable theme
+  command: wp theme enable {{ theme }} --network
+  args:
+    chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
+  with_dict: "{{ wordpress_sites }}"
+  become: true
+  become_user: "{{ web_user }}"

--- a/roles/local-development/tasks/main.yml
+++ b/roles/local-development/tasks/main.yml
@@ -1,0 +1,44 @@
+- name: Network activate Pressbooks
+  command: wp plugin activate pressbooks --network --allow-root
+  args:
+    chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
+  with_dict: "{{ wordpress_sites }}"
+- name: List themes
+  command: wp theme list --allow-root
+  args:
+    chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
+  with_dict: "{{ wordpress_sites }}"
+- name: Enable default themes
+  command: wp theme enable {{ item[0] }} --network --allow-root
+  args:
+    chdir: "{{ www_root }}/{{ item[1].key }}/{{ item[0].value.current_path | default('current') }}/"
+  with_dict:
+    - ['pressbooks-book', 'pressbooks-custom-css', 'pressbooks-publisher', 'austen', 'clarke', 'donham', 'fitzgerald']
+    - "{{ wordpress_sites }}"
+- name: Allow new book registration
+  command: wp network meta update 1 registration blog --allow-root
+  args:
+    chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
+  with_dict: "{{ wordpress_sites }}"
+- name: Allow book-level plugin administration
+  commaned: wp network meta update 1 menu_items '{"plugins":"1"}' --format=json --allow-root
+  args:
+    chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
+  with_dict: "{{ wordpress_sites }}"
+- name: Update network title
+  command: wp network meta update 1 site_name Pressbooks --allow-root
+  args:
+    chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
+  with_dict: "{{ wordpress_sites }}"
+- name: Create unit testing database
+  mysql_db:
+    name: pressbooks_tests
+    state: present
+    login_host: "{{ site_env.db_host }}"
+    login_user: "{{ mysql_root_user }}"
+    login_password: "{{ mysql_root_password }}"
+- name: Install unit testing framework
+  command: bash bin/install-wp-tests.sh pressbooks_tests {{ mysql_root_user }} {{ mysql_root_password }}
+  args:
+    chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/web/wp-content/plugins/pressbooks/"
+  with_dict: "{{ wordpress_sites }}"

--- a/roles/local-development/tasks/main.yml
+++ b/roles/local-development/tasks/main.yml
@@ -1,44 +1,65 @@
 - name: Network activate Pressbooks
-  command: wp plugin activate pressbooks --network --allow-root
+  command: wp plugin activate pressbooks --network
   args:
     chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
   with_dict: "{{ wordpress_sites }}"
+  become: true
+  become_user: "{{ web_user }}"
 - name: List themes
-  command: wp theme list --allow-root
+  command: wp theme list
   args:
     chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
   with_dict: "{{ wordpress_sites }}"
+  become: true
+  become_user: "{{ web_user }}"
 - name: Enable default themes
-  command: wp theme enable {{ item[0] }} --network --allow-root
-  args:
-    chdir: "{{ www_root }}/{{ item[1].key }}/{{ item[0].value.current_path | default('current') }}/"
-  with_dict:
-    - ['pressbooks-book', 'pressbooks-custom-css', 'pressbooks-publisher', 'austen', 'clarke', 'donham', 'fitzgerald']
-    - "{{ wordpress_sites }}"
+  include: enable-theme.yml
+  with_items:
+    - pressbooks-book
+    - pressbooks-custom-css
+    - pressbooks-publisher
+    - clarke
+    - donham
+    - fitzgerald
+  loop_control:
+    loop_var: theme
 - name: Allow new book registration
-  command: wp network meta update 1 registration blog --allow-root
+  command: wp network meta update 1 registration blog
   args:
     chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
   with_dict: "{{ wordpress_sites }}"
+  become: true
+  become_user: "{{ web_user }}"
 - name: Allow book-level plugin administration
-  commaned: wp network meta update 1 menu_items '{"plugins":"1"}' --format=json --allow-root
+  command: wp network meta update 1 menu_items '{"plugins":"1"}' --format=json
   args:
     chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
   with_dict: "{{ wordpress_sites }}"
+  become: true
+  become_user: "{{ web_user }}"
 - name: Update network title
-  command: wp network meta update 1 site_name Pressbooks --allow-root
+  command: wp network meta update 1 site_name Pressbooks
   args:
     chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
   with_dict: "{{ wordpress_sites }}"
+  become: true
+  become_user: "{{ web_user }}"
+- name: Install Subversion
+  apt:
+    name: subversion
+    state: present
 - name: Create unit testing database
   mysql_db:
     name: pressbooks_tests
     state: present
+- name: Create/assign unit testing database user to db and grant permissions
+  mysql_user:
+    name: pressbooks_test
+    password: ''
+    append_privs: yes
+    priv: "pressbooks_tests.*:ALL"
+    state: present
     login_host: "{{ site_env.db_host }}"
     login_user: "{{ mysql_root_user }}"
     login_password: "{{ mysql_root_password }}"
-- name: Install unit testing framework
-  command: bash bin/install-wp-tests.sh pressbooks_tests {{ mysql_root_user }} {{ mysql_root_password }}
-  args:
-    chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/web/wp-content/plugins/pressbooks/"
   with_dict: "{{ wordpress_sites }}"


### PR DESCRIPTION
This role:

* Network activates Pressbooks.
* Network enables core themes.
* Enables book (blog) registration by logged-in users.
* Enables the plugin menu at the book level.
* Updates the network title to “Pressbooks”.
* Creates a database for running PHPUnit tests.
* Installs the PHPUnit testing framework for Pressbooks.