### PR TITLE
Saxon requires HTTPS instead of HTTP

### DIFF
--- a/roles/saxon-he/tasks/main.yml
+++ b/roles/saxon-he/tasks/main.yml
@@ -9,6 +9,6 @@
     group_id: net.sf.saxon
     artifact_id: Saxon-HE
     version: "{{ saxon_he_version }}"
-    repository_url: http://repo1.maven.org/maven2
+    repository_url: https://repo1.maven.org/maven2
     dest: /opt/saxon-he/saxon-he.jar
     mode: 0755


### PR DESCRIPTION
Saxon requires HTTPS instead of HTTP